### PR TITLE
Добавил установку пакета со шрифтами ttf-mscorefonts-installer

### DIFF
--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -1,12 +1,14 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula \
+    select true | debconf-set-selections
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libpango1.0-dev libc6-dev \
+    && apt-get install -y --no-install-recommends ttf-mscorefonts-installer libpango1.0-dev libc6-dev  \
      libgif-dev git autoconf libtool automake build-essential gettext libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/mono/libgdiplus
 WORKDIR /libgdiplus
-RUN ./autogen.sh --with-pango
-RUN make
-RUN make install
-RUN ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so
+RUN ./autogen.sh --with-pango \
+    && make \
+    && make install \
+    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so


### PR DESCRIPTION
Для принятия лицензионного соглашения eula используем debconf-set-selections.
Описание пакета: https://packages.debian.org/ru/sid/ttf-mscorefonts-installer
Локально проверил, что образ корректно собирается.