### PR TITLE
Добавил удаление папки в которой собирался libgdiplus

### DIFF
--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -11,5 +11,6 @@ WORKDIR /libgdiplus
 RUN ./autogen.sh --with-pango \
     && make \
     && make install \
-    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so \
-    && rm -rf /libgdiplus
+    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so
+WORKDIR /
+RUN rm -rf /libgdiplus

--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /libgdiplus
 RUN ./autogen.sh --with-pango \
     && make \
     && make install \
-    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so
+    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so \
     && rm -rf /libgdiplus

--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -12,3 +12,4 @@ RUN ./autogen.sh --with-pango \
     && make \
     && make install \
     && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so
+    && rm -rf /libgdiplus


### PR DESCRIPTION
## Что сделано
+ Добавил удаление папки в которой собирался libgdiplus, это позволило сократить объем дельты образов на 100Мб.
## Как протестировано
+ Убедился что образ собирается без ошибок
+ Зашел в контейнер и проверил что папки libgdiplus в корне диска нет, что текущая директория - корень.