### PR TITLE
Базовый образ с КриптоПро и расширением ГОСТ для openssl.

### DIFF
--- a/2.2/bionic_with_pango_and_gost_crypto/Dockerfile
+++ b/2.2/bionic_with_pango_and_gost_crypto/Dockerfile
@@ -1,0 +1,34 @@
+FROM directum/netcore:2.2-bionic
+
+# Ставим криптопро и прибираем за собой.
+COPY . /tmp/src
+RUN	cd /tmp/src \
+    && md5sum -c md5sums.txt \
+    && tar -xf cryptopro-linux-amd64_deb.tgz \
+    && linux-amd64_deb/install.sh \
+    && rm -rf /tmp/src
+
+# Делаем симлинки на утилиты криптопро.
+RUN cd /bin \
+    && ln -s /opt/cprocsp/bin/amd64/certmgr \
+    && ln -s /opt/cprocsp/bin/amd64/cpverify \
+    && ln -s /opt/cprocsp/bin/amd64/cryptcp \
+    && ln -s /opt/cprocsp/bin/amd64/csptest \
+    && ln -s /opt/cprocsp/bin/amd64/csptestf \
+    && ln -s /opt/cprocsp/bin/amd64/der2xer \
+    && ln -s /opt/cprocsp/bin/amd64/inittst \
+    && ln -s /opt/cprocsp/bin/amd64/wipefile \
+    && ln -s /opt/cprocsp/sbin/amd64/cpconfig
+
+# Ставим расширение ГОСТ для openssl и прибираем за собой.
+RUN apt-get update \
+    && apt-get install -y libengine-gost-openssl1.1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Конфигурируем openssl на работу с расширением ГОСТ.
+RUN sed -i "1s/^/openssl_conf = openssl_def\n/" /usr/lib/ssl/openssl.cnf \
+    && echo "[openssl_def]\nengines = engine_section\n\n[engine_section]\ngost = gost_section\n\n[gost_section]\nengine_id = gost\ndefault_algorithms = ALL\nCRYPT_PARAMS = id-Gost28147-89-CryptoPro-A-ParamSet" >> /usr/lib/ssl/openssl.cnf
+
+# Говорим .Net работать с openssl версии 1.1, без этого не будет работать валидация сертификатов ГОСТ.
+ENV CLR_OPENSSL_VERSION_OVERRIDE=1.1

--- a/2.2/bionic_with_pango_and_gost_crypto/md5sums.txt
+++ b/2.2/bionic_with_pango_and_gost_crypto/md5sums.txt
@@ -1,0 +1,2 @@
+# КриптоПро CSP 5.0.11944 (Jackalope) от 28.09.2020.
+d7d4e3d09b069fc847eaec7c8327e1a2  cryptopro-linux-amd64_deb.tgz


### PR DESCRIPTION
## Что сделано
+ Взял в качестве базового `directum/netcore:2.2-bionic`.
+ Образ КриптоПро взял версии 5.0.11944 с оф. сайта, была идея выкачивать при сборке контейнера, но он не дает напрямую это сделать, потому положил рядом и сделал проверку целостности через `md5sum` (контрольную сумму взял с сайта).
+ Помимо КриптоПро устанавливается расширение ГОСТ для openssl.
+ Расширение ГОСТ для openssl прописывается в конфиг openssl.
+ Добавляется переменная окружения `CLR_OPENSSL_VERSION_OVERRIDE` - это для того, чтобы .Net смог работать с расширением ГОСТ для openssl (требуется при проверке цепочки сертификатов).

## Как протестировано
+ Убедился что образ собирается без ошибок
+ Зашел в контейнер и проверил:
  + Работу КриптоПро командами `csptest -keyset -verifycontext | sed -n 's/.* Ver:*\([0-9.]\+\).*/\1/p'` (вывод версии) и `cpconfig -license -view` (информация о лицензии) - выполняются, показывают ожидаемые данные;
  + Работу расширения ГОСТ для openssl командой `openssl ciphers|tr ':' '\n'|grep GOST` - вывод команды не пустой, расширение активировалось;
  + Командой `set | grep CLR_OPENSSL_VERSION_OVERRIDE` убедился, что переменная окружения `CLR_OPENSSL_VERSION_OVERRIDE` установлена.