### PR TITLE
Поправил базовый образ для 3.1: добавил krb5-user, убрал лишнее.

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgdiplus libc6-dev \
+    && apt-get install -y --no-install-recommends krb5-user \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Что сделано
+ Для работы Kerberos на ClientHost нужен пакет krb5-user, добавил.
+ Т.к. этот базовый образ используется только для ClientHost, то libgdiplus и libc6-dev тут не нужны, их убрал.

## Как проверялось
+ Убедился что образ собирается
+ Проверил работу ClientHost на этом образе - работает, в т.ч. с Kerberos аутентификацией.