### PR TITLE
Очищаем предопределенные адреса прослушивания ASP.NET Core

### DIFF
--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -25,3 +25,6 @@ ENV LANG ru_RU.UTF-8
 ENV LC_ALL ru_RU.UTF-8
 RUN echo "ru_RU.CP866 IBM866" >> /etc/locale.gen \
     && locale-gen
+
+# Очищаем предопределенные адреса прослушивания ASP.NET Core, что бы не было warning-ов при старте сервисов.
+ENV ASPNETCORE_URLS=

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -3,3 +3,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends krb5-user \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Очищаем предопределенные адреса прослушивания ASP.NET Core, что бы не было warning-ов при старте сервисов.
+ENV ASPNETCORE_URLS=


### PR DESCRIPTION
## Что сделано
+ Добавил очистку переменной окружения ASPNETCORE_URLS, которая приходит из базовых образов, без этого при старте сервисов идет warning в лог + может быть, в теории, нежелательное поведение.

## Как проверено
+ Пересобрал сервисы, посмотрел в логи - warning исчезли, на работоспособность не сказалось