### PR TITLE
Базовый образ переведен на multistage build

### DIFF
--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -8,9 +8,7 @@ RUN git clone https://github.com/mono/libgdiplus
 WORKDIR /libgdiplus
 RUN ./autogen.sh --with-pango \
     && make \
-    && make install    
-WORKDIR /
-RUN rm -rf /libgdiplus
+    && make install
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula \

--- a/2.2/bionic_with_pango/Dockerfile
+++ b/2.2/bionic_with_pango/Dockerfile
@@ -1,22 +1,29 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula \
-    select true | debconf-set-selections
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic as builder
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ttf-mscorefonts-installer gss-ntlmssp libpango1.0-dev libc6-dev language-pack-ru \
-     libgif-dev git autoconf libtool automake build-essential gettext libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev \
+    && apt-get install -y --no-install-recommends libpango1.0-dev libc6-dev \
+     libgif-dev git autoconf libtool automake build-essential libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/mono/libgdiplus
 WORKDIR /libgdiplus
 RUN ./autogen.sh --with-pango \
     && make \
-    && make install \
-    && ln -s /usr/local/lib/libgdiplus.so /usr/lib/libgdiplus.so
+    && make install    
+WORKDIR /
+RUN rm -rf /libgdiplus
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula \
+    select true | debconf-set-selections
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ttf-mscorefonts-installer gss-ntlmssp libpango1.0-dev libc6-dev \
+     libgif-dev libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev language-pack-ru \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*        
+COPY --from=builder /usr/local/lib/libgdiplus* /usr/lib/
 # Установка локализации в контейнере
 ENV LANGUAGE ru_RU.UTF-8
 ENV LANG ru_RU.UTF-8
 ENV LC_ALL ru_RU.UTF-8
 RUN echo "ru_RU.CP866 IBM866" >> /etc/locale.gen \
     && locale-gen
-WORKDIR /
-RUN rm -rf /libgdiplus


### PR DESCRIPTION
Перевел на multistage build
Сейчас в builder мы производим сборку libgdiplus, а в итоговый образ копируем эту библиотеку.
Это позволило сократить размер итогового образа на ~22%

**Как проверял**
Локально собрал image.
Развернул sungerowebserver и sungerowebclient.
Проверил работоспособность отчетов.