### PR TITLE
Образ со сборкой libgdiplus без pango

### DIFF
--- a/2.2/bionic_with_libgdiplus/Dockerfile
+++ b/2.2/bionic_with_libgdiplus/Dockerfile
@@ -1,11 +1,34 @@
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic as builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+     libpng-dev libgif-dev git autoconf libtool automake build-essential gettext libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/share
+RUN git clone https://github.com/mono/libgdiplus
+
+# HACK: patch max memory size
+WORKDIR /usr/local/share/libgdiplus/src
+RUN sed -i 's/1024/10240/g' region-bitmap.h
+
+WORKDIR /usr/local/share/libgdiplus
+RUN ./autogen.sh \
+    && make \
+    && make install
+
+WORKDIR /usr/local/share
+RUN rm -r libgdiplus
+
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula \
     select true | debconf-set-selections
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ttf-mscorefonts-installer gss-ntlmssp libc6-dev \
-     language-pack-ru gnupg1 libgdiplus \
+     libgif-dev libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev language-pack-ru gnupg1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* 
+COPY --from=builder /usr/local/lib/libgdiplus* /usr/lib/
 
 # Установка локализации в контейнере
 ENV LANGUAGE ru_RU.UTF-8

--- a/2.2/bionic_with_libgdiplus/Dockerfile
+++ b/2.2/bionic_with_libgdiplus/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /usr/local/share
 RUN git clone https://github.com/mono/libgdiplus
 
 # HACK: patch max memory size
+# см. [https://forum.aspose.com/t/pdf-to-image-dotnetcore-2-1-error-region-cgdipcombineregionpath-assertion-failed-region-bitmap/178516/28]
 WORKDIR /usr/local/share/libgdiplus/src
 RUN sed -i 's/1024/10240/g' region-bitmap.h
 


### PR DESCRIPTION
**Проблема**
У предыдущей версии образа bionic-with-libgdiplus вылезли проблемы с некоторыми PDF - контейнер либо падал, либо вылезала ошибка OutOfMemory.

**Решение**
Взял за основу "рабочий" образ bionic-with-pango, вырезал из него всё, что касается pango - сработало, PPT(X) начали нормально конвертироваться. 
Но вылез визуальный баг, когда некоторые страницы конвертировались "не по размеру", т.е были больше остальных, при этом в логах были warning'и от libgdiplus - решилось с помощью небольшого хака по увеличению памяти.

**Тестирование**
Проверили работу на ppt(x), pdf - всё работает корректно.
Тестовые файлы см. баг #130969